### PR TITLE
Modifed version import to be Python 3 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import setup, Extension
 from setuptools.dist import Distribution
 
-execfile('cyglfw3/version.py')
+exec(open("./cyglfw3/version.py").read())
 
 # auto-install cython
 Distribution(dict(setup_requires='Cython'))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ import sys
 from setuptools import setup, Extension
 from setuptools.dist import Distribution
 
-exec(open("./cyglfw3/version.py").read())
+with open("./cyglfw3/version.py") as versionfile:
+    exec(versionfile.read())
 
 # auto-install cython
 Distribution(dict(setup_requires='Cython'))


### PR DESCRIPTION
Quick modification to allow cyglfw3 to be built on Python 3 (see Issue #14). Doesn't address clever things like automunging Python unicode strings to Cython byte strings or such (which would need to be one in the generation scripts), but does appear to work on OS X at least.
